### PR TITLE
Detect when the client closes a connection

### DIFF
--- a/Dirmi/src/main/java/org/cojen/dirmi/io/BasicChannelBroker.java
+++ b/Dirmi/src/main/java/org/cojen/dirmi/io/BasicChannelBroker.java
@@ -216,7 +216,7 @@ abstract class BasicChannelBroker implements ChannelBroker {
      */
     protected abstract boolean requirePingTask();
 
-    protected abstract boolean doPing() throws IOException;
+    protected abstract void doPing() throws IOException;
 
     void logPingMessage(String message) {
         if (cPingLogger != null) {
@@ -287,12 +287,8 @@ abstract class BasicChannelBroker implements ChannelBroker {
 
         @Override
         boolean doTask(BasicChannelBroker broker) throws IOException {
-            if (broker.doPing()) {
-                broker.pinged();
-                return true;
-            } else {
-                return false;
-            }
+            broker.doPing();
+            return true;
         }
     }
 

--- a/Dirmi/src/main/java/org/cojen/dirmi/io/BasicChannelBrokerConnector.java
+++ b/Dirmi/src/main/java/org/cojen/dirmi/io/BasicChannelBrokerConnector.java
@@ -307,7 +307,7 @@ public class BasicChannelBrokerConnector implements ChannelBrokerConnector {
         }
 
         @Override
-        protected boolean doPing() {
+        protected void doPing() {
             // Should not be called.
             throw new AssertionError();
         }

--- a/DirmiTestSuite/src/test/java/org/cojen/dirmi/TestSessionAcceptor.java
+++ b/DirmiTestSuite/src/test/java/org/cojen/dirmi/TestSessionAcceptor.java
@@ -112,9 +112,8 @@ public class TestSessionAcceptor {
     public void connectTimeout() throws IOException {
         // A large connect timeout. The timeout is high enough that the call should easily
         // finish without timing out. For this test to cover the right paths, this timeout
-        // (when converted to seconds) must be lower than
-        // StandardSession.CREATE_TIMEOUT_SECONDS.
-        final int SUCCESS_TIMEOUT_MS = 14_000;
+        // must be lower than BasicChannelBroker.PING_DELAY_MILLIS.
+        final int SUCCESS_TIMEOUT_MS = 2_400;
         // Call ping() once without timing it, to warm up the caches
         ping(SUCCESS_TIMEOUT_MS);
 
@@ -135,7 +134,8 @@ public class TestSessionAcceptor {
                 timeouts++;
                 // This test purposely uses a timeout that is too low, so this exception is
                 // expected. Now that the client has timed out, verify the server is still
-                // healthy.
+                // healthy, and can process a new session without waiting for the old session
+                // to fail a ping.
                 ping(SUCCESS_TIMEOUT_MS);
             }
         }


### PR DESCRIPTION
On the server, instead of waiting for a ping to get sent to detect when the
client closes the connection, directly listen for close events.